### PR TITLE
Login時のユーザー ネームのバリデーション障害

### DIFF
--- a/functions/Auth/src/controllers/login.go
+++ b/functions/Auth/src/controllers/login.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"EX/auth/src/middleware"
+	"EX/auth/src/models"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -50,19 +51,26 @@ func Login(c *gin.Context) {
 		If doesn't exit user information that Login controller response error status.
 	*/
 
-	// Create JWT token
-	token, err := middleware.AuthMiddleware(1)
+	suc := models.Login(name, pass)
 
-	if err != nil {
-		c.JSON(http.StatusUnprocessableEntity, err.Error())
-		return
+	if suc != nil {
+		c.String(http.StatusBadRequest, "Bad Request")
 	}
 
-	var response = Response{
-		ID:       token,
-		Username: user.Username,
-	}
+	if suc == nil {
+		// Create JWT token
+		token, err := middleware.AuthMiddleware(1)
 
-	// If get user information succesfull that Login controller response success status.
-	c.JSON(http.StatusOK, response)
+		if err != nil {
+			c.JSON(http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+
+		var response = Response{
+			ID:       token,
+			Username: user.Username,
+		}
+		// If get user information succesfull that Login controller response success status.
+		c.JSON(http.StatusOK, response)
+	}
 }

--- a/functions/Auth/src/models/login.go
+++ b/functions/Auth/src/models/login.go
@@ -4,13 +4,12 @@ import (
 	"EX/auth/src/database"
 	"EX/auth/src/lib"
 	"errors"
-	"fmt"
 
 	"gorm.io/gorm"
 )
 
-// LoginUser get user information for database
-type LoginUser struct {
+// USER get user information for database
+type USER struct {
 	gorm.Model
 	ID       string `json:"id"`
 	Username string `json:"username"`
@@ -27,8 +26,9 @@ func Login(name string, password string) error {
 
 	db := database.DBConnect
 
-	var user LoginUser
-	// var hashPass error
+	var user USER
+
+	// var username string
 
 	user.Username = name
 	user.Password = password
@@ -49,12 +49,13 @@ func Login(name string, password string) error {
 
 	hashPass := lib.CompareHashPassword(conPass, user.Password)
 
-	if hashPass == nil {
-		if err := db.Where("username = ? AND password = ?", user.Username, user.Password).First(&user).Error; err != nil {
-			fmt.Println(&user)
-			return nil
-		}
+	if hashPass != nil {
+		return errors.New("Failed compare password")
 	}
 
-	return errors.New("Failed login")
+	if err := db.Debug().Where("username = ?", name).Take(&user).Error; err != nil {
+		return errors.New("Failed Login")
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Login時のユーザー ネームのバリデーション障害

**障害原因**

- controllersにmodels/Loginの機能を搭載していなかった

***

上記の原因があったので、controllers/Loginにmodels/loginの機能を搭載しました。

機能実装時に発生した問題点

- ログイン時のユーザーネームバリデーションを実装することにより既存のユーザーのみのログインは可能になったが、ハッシュ化されたパスワードと入力されたパスワードの比較を行うことができていない。

上記問題点は今度の問題になりうるのでフロントの機能実装が完了次第に早期修正を行う。